### PR TITLE
修复lld链接kernel64.lto.o的时候relocation R_X86_64_32 out of range的错误

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -43,6 +43,8 @@ target("pl_readline")
     add_cflags("-mno-80387", "-mno-mmx", "-DNDEBUG")
     add_cflags("-mno-sse", "-mno-sse2", "-mno-red-zone")
     add_cflags("-nostdlib", "-fno-builtin", "-fno-stack-protector")
+    add_cflags("-fPIC")
+    add_cxflags("-fPIC")
 
 target("kernel32")
     set_arch("i386")
@@ -77,6 +79,8 @@ target("kernel64")
     add_cflags("-fno-stack-protector", "-flto", "-fPIC")
     add_cflags("-mno-80387", "-mno-mmx", "-mno-sse", "-mno-sse2")
     add_cflags("-mno-red-zone", "-nostdinc", "-msoft-float")
+    add_cflags("-mcmodel=kernel")  -- 添加内存模型设置
+    add_ldflags("-no-pie")         -- 显式禁用位置无关可执行文件
     add_ldflags("-T src/x86_64/linker.ld", "-nostdlib", "-fuse-ld=lld")
 
     --add_cflags("-fsanitize=undefined")


### PR DESCRIPTION
废话不多说先上错误信息
```
linzhichen@LinZhichen-114514:~/CoolPotOS$ xmake clean && xmake run run64
[  5%]: cache compiling.release thirdparty/limine/limine.c
[  6%]: cache compiling.release thirdparty/pl_readline/src/plreadln_intellisense.c
[  7%]: cache compiling.release thirdparty/pl_readline/src/plreadln.c
[  8%]: cache compiling.release thirdparty/pl_readline/src/plreadln_wordmk.c
[  9%]: linking.release limine
In file included from thirdparty/pl_readline/src/plreadln_intellisense.c:16:
In file included from thirdparty/pl_readline/include/pl_readline.h:8:
thirdparty/pl_readline/include/pl_list.h:141:15: warning: unused function 'list_free' [-Wunused-function]
  141 | static list_t list_free(list_t list) {
      |               ^~~~~~~~~
thirdparty/pl_readline/include/pl_list.h:149:15: warning: unused function 'list_free_with' [-Wunused-function]
  149 | static list_t list_free_with(list_t list, void (*free_data)(void *)) {
      |               ^~~~~~~~~~~~~~
thirdparty/pl_readline/include/pl_list.h:159:15: warning: unused function 'list_append' [-Wunused-function]
  159 | static list_t list_append(list_t list, void *data) {
      |               ^~~~~~~~~~~
thirdparty/pl_readline/include/pl_list.h:210:15: warning: unused function 'list_nth' [-Wunused-function]
  210 | static list_t list_nth(list_t list, size_t n) {
      |               ^~~~~~~~
thirdparty/pl_readline/include/pl_list.h:220:15: warning: unused function 'list_nth_last' [-Wunused-function]
  220 | static list_t list_nth_last(list_t list, size_t n) {
In file included from thirdparty/pl_readline/src/plreadln.c:18:
In file included from thirdparty/pl_readline/include/pl_readline.h:8:
thirdparty/pl_readline/include/pl_list.h:141:15: warning: unused function 'list_free' [-Wunused-function]
  141 | static list_t list_free(list_t list) {
      |               ^~~~~~~~~
thirdparty/pl_readline/include/pl_list.h:159:15: warning: unused function 'list_append' [-Wunused-function]
  159 | static list_t list_append(list_t list, void *data) {
      |               ^~~~~~~~~~~
thirdparty/pl_readline/include/pl_list.h:220:15: warning: unused function 'list_nth_last' [-Wunused-function]
  220 | static list_t list_nth_last(list_t list, size_t n) {
      |               ^~~~~~~~~~~~~
thirdparty/pl_readline/include/pl_list.h:230:13: warning: unused function 'list_search' [-Wunused-function]
  230 | static bool list_search(list_t list, void *data) {
      |             ^~~~~~~~~~~
thirdparty/pl_readline/include/pl_list.h:239:15: warning: unused function 'list_delete' [-Wunused-function]
  239 | static list_t list_delete(list_t list, void *data) {
In file included from thirdparty/pl_readline/src/plreadln_wordmk.c:17:
In file included from thirdparty/pl_readline/include/pl_readline.h:8:
thirdparty/pl_readline/include/pl_list.h:141:15: warning: unused function 'list_free' [-Wunused-function]
  141 | static list_t list_free(list_t list) {
      |               ^~~~~~~~~
thirdparty/pl_readline/include/pl_list.h:149:15: warning: unused function 'list_free_with' [-Wunused-function]
  149 | static list_t list_free_with(list_t list, void (*free_data)(void *)) {
      |               ^~~~~~~~~~~~~~
thirdparty/pl_readline/include/pl_list.h:159:15: warning: unused function 'list_append' [-Wunused-function]
  159 | static list_t list_append(list_t list, void *data) {
      |               ^~~~~~~~~~~
thirdparty/pl_readline/include/pl_list.h:210:15: warning: unused function 'list_nth' [-Wunused-function]
  210 | static list_t list_nth(list_t list, size_t n) {
      |               ^~~~~~~~
thirdparty/pl_readline/include/pl_list.h:220:15: warning: unused function 'list_nth_last' [-Wunused-function]
  220 | static list_t list_nth_last(list_t list, size_t n) {
[ 10%]: archiving.release libpl_readline.a
    Finished `release` profile [optimized] target(s) in 0.53s
WARN: Skip libos-terminal::ALLOCATOR - (not `no_mangle`).
WARN: Skip libos-terminal::MALLOC - (not `no_mangle`).
WARN: Skip libos-terminal::FREE - (not `no_mangle`).
WARN: Skip libos-terminal::TERMINAL - (not `no_mangle`).
[ 18%]: cache compiling.release src/x86_64/utils/klog.c
[ 19%]: cache compiling.release src/x86_64/utils/elf_util.c
[ 20%]: cache compiling.release src/x86_64/utils/crc.c
[ 21%]: cache compiling.release src/x86_64/utils/stb_impl.c
[ 23%]: cache compiling.release src/x86_64/utils/krlibc.c
[ 24%]: cache compiling.release src/x86_64/utils/kprint.c
[ 25%]: cache compiling.release src/x86_64/utils/mpmc_queue.c
[ 26%]: cache compiling.release src/x86_64/utils/atom_queue.c
[ 27%]: cache compiling.release src/x86_64/utils/lock_queue.c
[ 28%]: cache compiling.release src/x86_64/as-linux-app.c
[ 29%]: cache compiling.release src/x86_64/cpu/empty_interrupt.c
[ 30%]: cache compiling.release src/x86_64/cpu/error_handle.c
[ 31%]: cache compiling.release src/x86_64/cpu/cpuid.c
[ 32%]: cache compiling.release src/x86_64/cpu/idt.c
[ 34%]: cache compiling.release src/x86_64/cpu/fpu.c
[ 35%]: cache compiling.release src/x86_64/cpu/smp.c
[ 36%]: cache compiling.release src/x86_64/cpu/gdt.c
[ 37%]: cache compiling.release src/x86_64/mem/bitmap.c
[ 38%]: cache compiling.release src/x86_64/mem/page.c
src/x86_64/utils/lock_queue.c:133:6: warning: expression result unused [-Wunused-value]
  133 |     (!__atomic_test_and_set(&(q->lock), 5));
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/x86_64/utils/lock_queue.c:143:6: warning: expression result unused [-Wunused-value]
  143 |     (!__atomic_test_and_set(&(q->lock), 5));
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
src/x86_64/as-linux-app.c:34:389: warning: expression result unused [-Wunused-value]
   34 |         ({ long int rets; long int __arg1 = (long int)(fd); long int __arg2 = (long int)(&buf[i]); long int __arg3 = (long int)(1); register long int _a3 __asm__("rdx") = __arg3; register long int _a2 __asm__("rsi") = __arg2; register long int _a1 __asm__("rdi") = __arg1; __asm__ volatile("syscall\n\t" : "=a"(rets) : "0"(1), "r"(_a1), "r"(_a2), "r"(_a3) : "memory", "cc", "r11", "cx"); rets; });
      |                                                                                                                                                                                                                                                                                                                                                                                                     ^~~~
src/x86_64/as-linux-app.c:49:204: warning: expression result unused [-Wunused-value]
   49 |     ({ long int rets; long int __arg1 = (long int)(status); register long int _a1 __asm__("rdi") = __arg1; __asm__ volatile("syscall\n\t" : "=a"(rets) : "0"(60), "r"(_a1) : "memory", "cc", "r11", "cx"); rets; });
      |                                                                                                                                                                                                            ^~~~
src/x86_64/as-linux-app.c:66:6: warning: incompatible redeclaration of library function 'printf' [-Wincompatible-library-redeclaration]
   66 | void printf(const char *fmt, ...) {
      |      ^
src/x86_64/as-linux-app.c:66:6: note: 'printf' is a builtin with type 'int (const char *, ...)'
src/x86_64/as-linux-app.c:107:203: warning: expression result unused [-Wunused-value]
  107 |     ({ long int rets; long int __arg1 = (long int)(&info); register long int _a1 __asm__("rdi") = __arg1; __asm__ volatile("syscall\n\t" : "=a"(rets) : "0"(63), "r"(_a1) : "memory", "cc", "r11", "cx"); rets; });
      |                                                                                                                                                                                                           ^~~~
src/x86_64/as-linux-app.c:149:399: warning: expression result unused [-Wunused-value]
  149 |             ({ long int rets; long int __arg1 = (long int)(argv[0]); long int __arg2 = (long int)(argv); long int __arg3 = (long int)(envp); register long int _a3 __asm__("rdx") = __arg3; register long int _a2 __asm__("rsi") = __arg2; register long int _a1 __asm__("rdi") = __arg1; __asm__ volatile("syscall\n\t" : "=a"(rets) : "0"(59), "r"(_a1), "r"(_a2), "r"(_a3) : "memory", "cc", "r11", "cx"); rets; });
      |                                                                                                                                                                                                                                                                                                                                                                                                               ^~~~
src/x86_64/cpu/error_handle.c:79:65: warning: unused parameter 'frame' [-Wunused-parameter]
   79 | __attribute__((interrupt)) void double_fault(interrupt_frame_t *frame, uint64_t error_code) {
      |                                                                 ^
src/x86_64/cpu/error_handle.c:79:81: warning: unused parameter 'error_code' [-Wunused-parameter]
   79 | __attribute__((interrupt)) void double_fault(interrupt_frame_t *frame, uint64_t error_code) {
      |                                                                                 ^
2 warnings generated.
[ 39%]: cache compiling.release src/x86_64/mem/frame.c
[ 40%]: cache compiling.release src/x86_64/mem/hhdm.c
[ 41%]: cache compiling.release src/x86_64/mem/heap/mman.c
[ 42%]: cache compiling.release src/x86_64/mem/heap/pool.c
[ 43%]: cache compiling.release src/x86_64/mem/heap/sized-pool.c
[ 45%]: cache compiling.release src/x86_64/mem/heap/heap.c
[ 46%]: cache compiling.release src/x86_64/driver/timer.c
[ 47%]: cache compiling.release src/x86_64/driver/iic/iic_basic.c
[ 48%]: cache compiling.release src/x86_64/driver/iic/pca9685.c
[ 49%]: cache compiling.release src/x86_64/driver/iic/iic_core.c
[ 50%]: cache compiling.release src/x86_64/driver/usb.c
[ 51%]: cache compiling.release src/x86_64/driver/dma.c
[ 52%]: cache compiling.release src/x86_64/driver/tty.c
[ 53%]: cache compiling.release src/x86_64/driver/gop.c
[ 54%]: cache compiling.release src/x86_64/driver/vdisk.c
[ 56%]: cache compiling.release src/x86_64/driver/pci/ahci.c
[ 57%]: cache compiling.release src/x86_64/driver/pci/nvme.c
[ 58%]: cache compiling.release src/x86_64/driver/pci/xhci.c
[ 59%]: cache compiling.release src/x86_64/driver/pci/pcnet.c
[ 60%]: cache compiling.release src/x86_64/driver/pci/rtl8169.c
src/x86_64/mem/heap/mman.c:217:26: warning: unused parameter 'man' [-Wunused-parameter]
  217 | size_t mman_msize(mman_t man, void *ptr) {
      |                          ^
1 warning generated.
src/x86_64/mem/heap/pool.c:149:28: warning: unused parameter 'pool' [-Wunused-parameter]
  149 | size_t mpool_msize(mpool_t pool, void *ptr) {
      |                            ^
1 warning generated.
src/x86_64/driver/iic/pca9685.c:43:28: warning: unused parameter 'reg' [-Wunused-parameter]
   43 | void pca9685_write(uint8_t reg, uint8_t data) {
      |                            ^
src/x86_64/driver/iic/pca9685.c:43:41: warning: unused parameter 'data' [-Wunused-parameter]
   43 | void pca9685_write(uint8_t reg, uint8_t data) {
      |                                         ^
src/x86_64/driver/iic/pca9685.c:54:30: warning: unused parameter 'reg' [-Wunused-parameter]
   54 | uint8_t pca9685_read(uint8_t reg) {
      |                              ^
3 warnings generated.
src/x86_64/driver/tty.c:19:37: warning: unused parameter 'tty' [-Wunused-parameter]
   19 | static void tty_kernel_print(tty_t *tty, const char *msg) {
      |                                     ^
src/x86_64/driver/tty.c:30:36: warning: unused parameter 'tty' [-Wunused-parameter]
   30 | static void tty_kernel_putc(tty_t *tty, int c) {
      |                                    ^
src/x86_64/driver/tty.c:61:28: warning: unused parameter 'drive' [-Wunused-parameter]
   61 | static void stdin_read(int drive, uint8_t *buffer, uint32_t number, uint32_t lba) {
      |                            ^
src/x86_64/driver/tty.c:61:78: warning: unused parameter 'lba' [-Wunused-parameter]
   61 | static void stdin_read(int drive, uint8_t *buffer, uint32_t number, uint32_t lba) {
      |                                                                              ^
src/x86_64/driver/tty.c:73:30: warning: unused parameter 'drive' [-Wunused-parameter]
   73 | static void stdout_write(int drive, uint8_t *buffer, uint32_t number, uint32_t lba) {
      |                              ^
src/x86_64/driver/tty.c:73:80: warning: unused parameter 'lba' [-Wunused-parameter]
src/x86_64/driver/iic/iic_basic.c:32:44: warning: unused parameter 'func' [-Wunused-parameter]
   32 | void iic_slaveForeach(list_t *head, void (*func)(IIC_Slave *)) {
      |                                            ^
src/x86_64/driver/iic/iic_basic.c:67:28: warning: unused parameter 'IIC_Master' [-Wunused-parameter]
   67 | void iic_start(IIC_Master *IIC_Master) {
      |                            ^
src/x86_64/driver/iic/iic_basic.c:71:27: warning: unused parameter 'IIC_Master' [-Wunused-parameter]
   71 | void iic_stop(IIC_Master *IIC_Master) {
      |                           ^
3 warnings generated.
[ 61%]: cache compiling.release src/x86_64/driver/pci/ide.c
[ 62%]: cache compiling.release src/x86_64/driver/pci/pci.c
[ 63%]: cache compiling.release src/x86_64/driver/acpi/acpi.c
[ 64%]: cache compiling.release src/x86_64/driver/acpi/power.c
[ 65%]: cache compiling.release src/x86_64/driver/acpi/apic.c
[ 67%]: cache compiling.release src/x86_64/driver/acpi/hpet.c
[ 68%]: cache compiling.release src/x86_64/driver/serial.c
[ 69%]: cache compiling.release src/x86_64/driver/input/keyboard.c
[ 70%]: cache compiling.release src/x86_64/driver/input/mouse.c
[ 71%]: cache compiling.release src/x86_64/driver/rtc.c
[ 72%]: cache compiling.release src/x86_64/driver/terminal.c
[ 73%]: cache compiling.release src/x86_64/driver/smbios.c
[ 74%]: cache compiling.release src/x86_64/driver/sound/sb16.c
[ 75%]: cache compiling.release src/x86_64/driver/sound/speaker.c
src/x86_64/driver/pci/xhci.c:28:39: warning: unused parameter 'frame' [-Wunused-parameter]
   28 | void InterruptXHCI(interrupt_frame_t *frame) {
      |                                       ^
src/x86_64/driver/pci/xhci.c:153:46: warning: unused parameter 'controller' [-Wunused-parameter]
  153 | uint32_t XHCIWaitCompletion(XHCI_CONTROLLER *controller, XHCI_TRANSFER_RING *ring) {
      |                                              ^
src/x86_64/driver/pci/xhci.c:162:29: warning: unused parameter 'arg' [-Wunused-parameter]
  162 | int usb_kernel_thread(void *arg) {
      |                             ^
src/x86_64/driver/pci/xhci.c:259:9: warning: unused variable 'count' [-Wunused-variable]
  259 |     int count = USBEnumerate(hub);
      |         ^~~~~
src/x86_64/driver/pci/xhci.c:274:1: warning: unused label 'FAILED' [-Wunused-label]
  274 | FAILED:;
      | ^~~~~~~
src/x86_64/driver/pci/xhci.c:343:37: warning: unused parameter 'hub' [-Wunused-parameter]
[ 76%]: cache compiling.release src/x86_64/fs/devfs.c
[ 78%]: cache compiling.release src/x86_64/fs/vfs.c
[ 79%]: cache compiling.release src/x86_64/fs/iso9660.c
[ 80%]: cache compiling.release src/x86_64/fs/modfs.c
src/x86_64/driver/pci/ide.c:180:33: warning: unused parameter 'selector' [-Wunused-parameter]
  180 |                        uint16_t selector, uint64_t edi) {
      |                                 ^
src/x86_64/driver/pci/ide.c:385:23: warning: cast to 'uint16_t *' (aka 'unsigned short *') from smaller integer type 'uint32_t' (aka 'unsigned int') [-Wint-to-pointer-cast]
  385 |     uint16_t *_word = (uint16_t *)edi;
      |                       ^~~~~~~~~~~~~~~
src/x86_64/driver/pci/ide.c:311:80: warning: unused parameter 'selector' [-Wunused-parameter]
  311 | uint8_t ide_atapi_read(uint8_t drive, uint32_t lba, uint8_t numsects, uint16_t selector,
      |                                                                                ^
src/x86_64/driver/pci/ide.c:422:20: warning: variable 'err' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
  422 |         } else if (ide_devices[drive].Type == 0x01)
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/x86_64/driver/pci/ide.c:425:45: note: uninitialized use occurs here
  425 |         package[0] = ide_print_error(drive, err);
      |                                             ^~~
src/x86_64/driver/pci/ide.c:422:16: note: remove the 'if' if its condition is always true
src/x86_64/driver/pci/pci.c:208:65: warning: unused parameter 'arg' [-Wunused-parameter]
  208 | uint32_t pci_read0(uint32_t b, uint32_t d, uint32_t f, uint32_t arg, uint32_t registeroffset) {
      |                                                                 ^
src/x86_64/driver/pci/pci.c:216:62: warning: unused parameter 'arg' [-Wunused-parameter]
  216 | void pci_write0(uint32_t b, uint32_t d, uint32_t f, uint32_t arg, uint32_t registeroffset,
      |                                                              ^
2 warnings generated.
src/x86_64/driver/input/keyboard.c:44:69: warning: unused parameter 'frame' [-Wunused-parameter]
   44 | __attribute__((interrupt)) void keyboard_handler(interrupt_frame_t *frame) {
      |                                                                     ^
src/x86_64/driver/input/keyboard.c:14:12: warning: unused variable 'caps_lock' [-Wunused-variable]
   14 | static int caps_lock, shift, ctrl = 0;
      |            ^~~~~~~~~
src/x86_64/driver/input/keyboard.c:14:23: warning: unused variable 'shift' [-Wunused-variable]
   14 | static int caps_lock, shift, ctrl = 0;
      |                       ^~~~~
src/x86_64/driver/input/keyboard.c:14:30: warning: unused variable 'ctrl' [-Wunused-variable]
   14 | static int caps_lock, shift, ctrl = 0;
      |                              ^~~~
4 warnings generated.
src/x86_64/driver/input/mouse.c:62:65: warning: unused parameter 'frame' [-Wunused-parameter]
   62 | __attribute__((interrupt)) void mouse_handle(interrupt_frame_t *frame) {
      |                                                                 ^
1 warning generated.
src/x86_64/driver/terminal.c:38:34: warning: unused parameter 'pVoid' [-Wunused-parameter]
   38 | int terminal_flush_service(void *pVoid) {
      |                                  ^
1 warning generated.
src/x86_64/driver/sound/sb16.c:16:72: warning: unused parameter 'frame' [-Wunused-parameter]
   16 | __attribute__((interrupt)) static void sb16_handler(interrupt_frame_t *frame) {
      |                                                                        ^
1 warning generated.
[ 81%]: cache compiling.release src/x86_64/task/scheduler.c
[ 82%]: cache compiling.release src/x86_64/task/signal.c
[ 83%]: cache compiling.release src/x86_64/task/ipc.c
[ 84%]: cache compiling.release src/x86_64/task/pcb.c
[ 85%]: cache compiling.release src/x86_64/kmod/dlinker.c
[ 86%]: cache compiling.release src/x86_64/kmod/module.c
[ 87%]: cache compiling.release src/x86_64/kmod/krsym.c
[ 89%]: cache compiling.release src/x86_64/service/shell.c
[ 90%]: cache compiling.release src/x86_64/service/sysuser.c
[ 91%]: cache compiling.release src/x86_64/service/killer.c
[ 92%]: cache compiling.release src/x86_64/service/cpusp.c
[ 93%]: cache compiling.release src/x86_64/service/syscall.c
[ 94%]: cache compiling.release src/x86_64/main.c
src/x86_64/fs/devfs.c:31:30: warning: unused parameter 'handle' [-Wunused-parameter]
   31 | static int devfs_mkdir(void *handle, const char *name, vfs_node_t node) {
      |                              ^
src/x86_64/fs/devfs.c:31:50: warning: unused parameter 'name' [-Wunused-parameter]
   31 | static int devfs_mkdir(void *handle, const char *name, vfs_node_t node) {
      |                                                  ^
src/x86_64/fs/devfs.c:36:29: warning: unused parameter 'handle' [-Wunused-parameter]
   36 | static int devfs_stat(void *handle, vfs_node_t node) {
      |                             ^
src/x86_64/fs/devfs.c:44:30: warning: unused parameter 'parent' [-Wunused-parameter]
   44 | static void devfs_open(void *parent, const char *name, vfs_node_t node) {
      |                              ^
src/x86_64/fs/devfs.c:114:43: warning: unused parameter 'req' [-Wunused-parameter]
  114 | static int devfs_ioctl(void *file, size_t req, void *arg) {
      |                                           ^
src/x86_64/fs/devfs.c:114:54: warning: unused parameter 'arg' [-Wunused-parameter]
src/x86_64/fs/vfs.c:135:28: warning: unused parameter 'name' [-Wunused-parameter]
  135 | int vfs_regist(const char *name, vfs_callback_t callback) {
      |                            ^
1 warning generated.
In file included from src/x86_64/fs/iso9660.c:1:
src/x86_64/include/iso9660.h:87:5: warning: field '' with variable sized type 'union (anonymous at src/x86_64/include/iso9660.h:87:5)' not at the end of a struct or class is a GNU extension [-Wgnu-variable-sized-type-not-at-end]
   87 |     union {
      |     ^
src/x86_64/fs/iso9660.c:266:25: warning: unused parameter 'parent' [-Wunused-parameter]
  266 | int iso9660_mkdir(void *parent, const char *name, vfs_node_t node) {
      |                         ^
src/x86_64/fs/iso9660.c:266:45: warning: unused parameter 'name' [-Wunused-parameter]
  266 | int iso9660_mkdir(void *parent, const char *name, vfs_node_t node) {
      |                                             ^
src/x86_64/fs/iso9660.c:266:62: warning: unused parameter 'node' [-Wunused-parameter]
  266 | int iso9660_mkdir(void *parent, const char *name, vfs_node_t node) {
      |                                                              ^
src/x86_64/fs/iso9660.c:270:26: warning: unused parameter 'parent' [-Wunused-parameter]
  270 | int iso9660_mkfile(void *parent, const char *name, vfs_node_t node) {
      |                          ^
src/x86_64/fs/modfs.c:19:30: warning: unused parameter 'handle' [-Wunused-parameter]
   19 | static int modfs_mkdir(void *handle, const char *name, vfs_node_t node) {
      |                              ^
src/x86_64/fs/modfs.c:19:50: warning: unused parameter 'name' [-Wunused-parameter]
   19 | static int modfs_mkdir(void *handle, const char *name, vfs_node_t node) {
      |                                                  ^
src/x86_64/fs/modfs.c:35:29: warning: unused parameter 'handle' [-Wunused-parameter]
   35 | static int modfs_stat(void *handle, vfs_node_t node) {
      |                             ^
src/x86_64/fs/modfs.c:44:30: warning: unused parameter 'parent' [-Wunused-parameter]
   44 | static void modfs_open(void *parent, const char *name, vfs_node_t node) {
      |                              ^
4 warnings generated.
src/x86_64/task/signal.c:26:44: warning: unused parameter 'signum' [-Wunused-parameter]
   26 | void setup_signal_thread(tcb_t thread, int signum, void *handler) {
      |                                            ^
1 warning generated.
src/x86_64/task/ipc.c:14:26: warning: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'int' [-Wsign-compare]
   14 |     for (size_t i = 0; i < pcb->ipc_queue->size; ++i) {
      |                        ~ ^ ~~~~~~~~~~~~~~~~~~~~
src/x86_64/task/ipc.c:27:26: warning: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'int' [-Wsign-compare]
   27 |     for (size_t i = 0; i < pcb->ipc_queue->size; ++i) {
      |                        ~ ^ ~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
src/x86_64/task/pcb.c:143:17: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
  143 |         if (pid == mesg->pid) {
      |             ~~~ ^  ~~~~~~~~~
src/x86_64/task/pcb.c:273:57: warning: unused parameter 'arg3' [-Wunused-parameter]
  273 | int process_control(int option, uint64_t arg2, uint64_t arg3, uint64_t arg4, uint64_t arg5) {
      |                                                         ^
src/x86_64/task/pcb.c:273:72: warning: unused parameter 'arg4' [-Wunused-parameter]
  273 | int process_control(int option, uint64_t arg2, uint64_t arg3, uint64_t arg4, uint64_t arg5) {
      |                                                                        ^
src/x86_64/task/pcb.c:273:87: warning: unused parameter 'arg5' [-Wunused-parameter]
  273 | int process_control(int option, uint64_t arg2, uint64_t arg3, uint64_t arg4, uint64_t arg5) {
      |                                                                                       ^
4 warnings generated.
src/x86_64/kmod/dlinker.c:33:39: warning: unused parameter 'ehdr' [-Wunused-parameter]
   33 |                           Elf64_Ehdr *ehdr, uint64_t offset) {
      |                                       ^
1 warning generated.
In file included from src/x86_64/service/shell.c:17:
In file included from thirdparty/pl_readline/include/pl_readline.h:8:
thirdparty/pl_readline/include/pl_list.h:141:15: warning: unused function 'list_free' [-Wunused-function]
  141 | static list_t list_free(list_t list) {
      |               ^~~~~~~~~
thirdparty/pl_readline/include/pl_list.h:149:15: warning: unused function 'list_free_with' [-Wunused-function]
  149 | static list_t list_free_with(list_t list, void (*free_data)(void *)) {
      |               ^~~~~~~~~~~~~~
thirdparty/pl_readline/include/pl_list.h:159:15: warning: unused function 'list_append' [-Wunused-function]
  159 | static list_t list_append(list_t list, void *data) {
      |               ^~~~~~~~~~~
thirdparty/pl_readline/include/pl_list.h:210:15: warning: unused function 'list_nth' [-Wunused-function]
  210 | static list_t list_nth(list_t list, size_t n) {
      |               ^~~~~~~~
thirdparty/pl_readline/include/pl_list.h:220:15: warning: unused function 'list_nth_last' [-Wunused-function]
  220 | static list_t list_nth_last(list_t list, size_t n) {
src/x86_64/service/syscall.c:193:222: warning: non-void function does not return a value [-Wreturn-type]
  193 | uint64_t syscall_sigret( uint64_t arg0 __attribute__((unused)), uint64_t arg1 __attribute__((unused)), uint64_t arg2 __attribute__((unused)), uint64_t arg3 __attribute__((unused)), uint64_t arg4 __attribute__((unused))) {}
      |                                                                                                                                                                                                                              ^
1 warning generated.
[ 95%]: linking.release kernel64
error: ld.lld: error: build/linux/x86_64/release/libpl_readline.a(plreadln.c.o):(function pl_readline_init: .text+0x178): relocation R_X86_64_32 out of range: 18446744071562687727 is not in [0, 4294967295]; references section '.rodata.str1.1'
>>> referenced by __cpp_plreadln.c.c

ld.lld: error: build/linux/x86_64/release/libpl_readline.a(plreadln.c.o):(function redisplay_buffer_with_colors: .text+0x4a3): relocation R_X86_64_32 out of range: 18446744071562685396 is not in [0, 4294967295]; references section '.rodata.str1.1'
>>> referenced by __cpp_plreadln.c.c

ld.lld: error: build/linux/x86_64/release/libpl_readline.a(plreadln.c.o):(function redisplay_buffer_with_colors: .text+0x6ad): relocation R_X86_64_32 out of range: 18446744071562695034 is not in [0, 4294967295]; references section '.rodata.str1.1'
>>> referenced by __cpp_plreadln.c.c

ld.lld: error: build/linux/x86_64/release/libpl_readline.a(plreadln.c.o):(function redisplay_buffer_with_colors: .text+0x805): relocation R_X86_64_32 out of range: 18446744071562685396 is not in [0, 4294967295]; references section '.rodata.str1.1'
>>> referenced by __cpp_plreadln.c.c

ld.lld: error: build/linux/x86_64/release/libpl_readline.a(plreadln.c.o):(function pl_readline_next_line: .text+0x88b): relocation R_X86_64_32 out of range: 18446744071562692895 is not in [0, 4294967295]; references section '.rodata.str1.1'
>>> referenced by __cpp_plreadln.c.c

ld.lld: error: build/linux/x86_64/release/libpl_readline.a(plreadln.c.o):(function pl_readline_handle_key: .text+0xa4f): relocation R_X86_64_32 out of range: 18446744071562692901 is not in [0, 4294967295]; references section '.rodata.str1.1'
>>> referenced by __cpp_plreadln.c.c

ld.lld: error: build/linux/x86_64/release/libpl_readline.a(plreadln.c.o):(function pl_readline_handle_key: .text+0xb92): relocation R_X86_64_32 out of range: 18446744071562692895 is not in [0, 4294967295]; references section '.rodata.str1.1'
>>> referenced by __cpp_plreadln.c.c

ld.lld: error: build/linux/x86_64/release/libpl_readline.a(plreadln.c.o):(function pl_readline_handle_key: .text+0xc14): relocation R_X86_64_32 out of range: 18446744071562687727 is not in [0, 4294967295]; references section '.rodata.str1.1'
>>> referenced by __cpp_plreadln.c.c

ld.lld: error: build/linux/x86_64/release/libpl_readline.a(plreadln.c.o):(function pl_readline_handle_key: .text+0xf4f): relocation R_X86_64_32 out of range: 18446744071562692895 is not in [0, 4294967295]; references section '.rodata.str1.1'
>>> referenced by __cpp_plreadln.c.c

ld.lld: error: build/linux/x86_64/release/libpl_readline.a(plreadln.c.o):(function pl_readline_handle_history: .text+0x1231): relocation R_X86_64_32 out of range: 18446744071562692901 is not in [0, 4294967295]; references section '.rodata.str1.1'
>>> referenced by __cpp_plreadln.c.c

ld.lld: error: build/linux/x86_64/release/libpl_readline.a(plreadln.c.o):(function pl_readline_handle_history: .text+0x1281): relocation R_X86_64_32 out of range: 18446744071562692901 is not in [0, 4294967295]; references section '.rodata.str1.1'
>>> referenced by __cpp_plreadln.c.c

ld.lld: error: build/linux/x86_64/release/libpl_readline.a(plreadln_intellisense.c.o):(function pl_readline_intellisense: .text+0x253): relocation R_X86_64_32 out of range: 18446744071562685403 is not in [0, 4294967295]; references section '.rodata.str1.1'
>>> referenced by __cpp_plreadln_intellisense.c.c

ld.lld: error: build/linux/x86_64/release/libpl_readline.a(plreadln_intellisense.c.o):(function pl_readline_intellisense: .text+0x2ac): relocation R_X86_64_32 out of range: 18446744071562695034 is not in [0, 4294967295]; references section '.rodata.str1.1'
>>> referenced by __cpp_plreadln_intellisense.c.c

ld.lld: error: build/linux/x86_64/release/libpl_readline.a(plreadln_intellisense.c.o):(function pl_readline_intellisense: .text+0x2ed): relocation R_X86_64_32 out of range: 18446744071562696400 is not in [0, 4294967295]; references section '.rodata.str1.1'
>>> referenced by __cpp_plreadln_intellisense.c.c

ld.lld: error: build/linux/x86_64/release/kernel64.lto.o:(function stbsp_vsprintfcb: .text.stbsp_vsprintfcb+0x337): relocation R_X86_64_32 out of range: 18446744071562729856 is not in [0, 4294967295]; references section '.rodata.str1.16'
>>> referenced by ld-temp.o

ld.lld: error: build/linux/x86_64/release/kernel64.lto.o:(function stbsp_vsprintfcb: .text.stbsp_vsprintfcb+0x33c): relocation R_X86_64_32 out of range: 18446744071562729904 is not in [0, 4294967295]; references section '.rodata.str1.16'
>>> referenced by ld-temp.o

ld.lld: error: build/linux/x86_64/release/kernel64.lto.o:(function stbsp_vsprintfcb: .text.stbsp_vsprintfcb+0x371): relocation R_X86_64_32 out of range: 18446744071562729856 is not in [0, 4294967295]; references section '.rodata.str1.16'
>>> referenced by ld-temp.o

ld.lld: error: build/linux/x86_64/release/kernel64.lto.o:(function stbsp_vsprintfcb: .text.stbsp_vsprintfcb+0x376): relocation R_X86_64_32 out of range: 18446744071562729904 is not in [0, 4294967295]; references section '.rodata.str1.16'
>>> referenced by ld-temp.o

ld.lld: error: build/linux/x86_64/release/kernel64.lto.o:(function stbsp_vsprintfcb: .text.stbsp_vsprintfcb+0x3a3): relocation R_X86_64_32 out of range: 18446744071562729856 is not in [0, 4294967295]; references section '.rodata.str1.16'
>>> referenced by ld-temp.o

ld.lld: error: build/linux/x86_64/release/kernel64.lto.o:(function stbsp_vsprintfcb: .text.stbsp_vsprintfcb+0x3a8): relocation R_X86_64_32 out of range: 18446744071562729904 is not in [0, 4294967295]; references section '.rodata.str1.16'
>>> referenced by ld-temp.o

ld.lld: error: too many errors emitted, stopping now (use --error-limit=0 to see all errors)
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```
我就把pl_readline增加了-fPIC编译选项，禁用了kernel64的PIE，设置了内存模型，完美解决