### PR TITLE
解决readme文件中官网链接跳转错误的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ Welcome to create pull requests or issues to this project. Then sit back and rel
 
 ### Contributors
 
-* Goto [CoolPotOS | Website](cpos.plos-clan.org) to see the contributors list.
+* Goto [CoolPotOS | Website](https://cpos.plos-clan.org) to see the contributors list.


### PR DESCRIPTION
解决readme文件中官网链接跳转错误的问题
<img width="1680" height="456" alt="1111111111" src="https://github.com/user-attachments/assets/23584eb5-59cd-41eb-88b5-719fd12e6cac" />
