### PR TITLE
解决中文readme文件中官网链接跳转错误的问题

### DIFF
--- a/readme/README-zh-CN.md
+++ b/readme/README-zh-CN.md
@@ -70,4 +70,4 @@ cmake --build build/ --target run
 
 ### 贡献者们
 
-* 前往 [CoolPotOS | Website](cpos.plos-clan.org) 查看贡献者列表
+* 前往 [CoolPotOS | Website](https://cpos.plos-clan.org) 查看贡献者列表


### PR DESCRIPTION
解决中文readme文件中官网链接跳转错误的问题
<img width="1680" height="456" alt="1111111111" src="https://github.com/user-attachments/assets/e2df13ba-2405-4822-96db-e64bd265f2f5" />
