### PR TITLE
修复readme文件的官网链接跳转错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ Welcome to create pull requests or issues to this project. Then sit back and rel
 
 ### Contributors
 
-* Goto [CoolPotOS | Website](cpos.plos-clan.org) to see the contributors list.
+* Goto [CoolPotOS | Website](https://cpos.plos-clan.org) to see the contributors list.


### PR DESCRIPTION

<img width="1680" height="456" alt="11111111" src="https://github.com/user-attachments/assets/9204eb54-a354-4680-b35f-7dbf86b6e25b" />
修复readme文件的官网链接跳转错误