### PR TITLE
修复中文readme文件的官网链接跳转错误

### DIFF
--- a/readme/README-zh-CN.md
+++ b/readme/README-zh-CN.md
@@ -70,4 +70,4 @@ cmake --build build/ --target run
 
 ### 贡献者们
 
-* 前往 [CoolPotOS | Website](cpos.plos-clan.org) 查看贡献者列表
+* 前往 [CoolPotOS | Website](https://cpos.plos-clan.org) 查看贡献者列表


### PR DESCRIPTION

<img width="1680" height="456" alt="11111111" src="https://github.com/user-attachments/assets/7004d3fa-1845-4dc6-9211-ae41deedee2c" />
修复中文readme文件的官网链接跳转错误